### PR TITLE
Update test vectors link so it resolves in doc.

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@ This DID Method does not support deactivating the DID Document.
 
     <section class="informative">
       <h2>Test Vectors</h2>
-      <p>For a full list of test vectors see <a href="/test-vectors">test vectors</a>.</p>
+      <p>For a full list of test vectors see <a href="/did-method-key/test-vectors">test vectors</a>.</p>
       
       <section class="informative">
         <h3>Ed25519 / X25519</h2>


### PR DESCRIPTION
Test vectors link wasn't resolving so fixed the path so that clinking on the link would resolve the test vector implementations correctly.