### PR TITLE
Use compressed EC keys

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,28 +336,28 @@ This DID Method does not support deactivating the DID Document.
 
       <section class="informative">
         <h3>P-256</h2>
-          <p>These DID always start with <code>zru</code>.</p>
+          <p>These DID always start with <code>zDn</code>.</p>
         <pre class="example">
-          did:key:zrurwcJZss4ruepVNu1H3xmSirvNbzgBk9qrCktB6kaewXnJAhYWwtP3bxACqBpzjZdN7TyHNzzGGSSH5qvZsSDir9z
-          did:key:zrusAFgBbf84b8mBz8Cmy8UoFWKV52EaeRnK86vnLo4Z5QoRypE6hXVPN2urevZMAMtcTaCDFLWBaE1Q3jmdb1FHgve
+          did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169
+          did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv
         </pre>
       </section>
 
       <section class="informative">
         <h3>P-384</h2>
-          <p>These DID always start with <code>zFw</code>.</p>
+          <p>These DID always start with <code>z82</code>.</p>
         <pre class="example">
-          did:key:zFwfeyrSyWdksRYykTGGtagWazFB5zS4CjQcxDMQSNmCTQB5QMqokx2VJz4vBB2hN1nUrYDTuYq3kd1BM5cUCfFD4awiNuzEBuoy6rZZTMCsZsdvWkDXY6832qcAnzE7YGw43KU
-          did:key:zFwepbBSaPFjt5T1zWptHaXugLNxHYABfJrDoAZRYxKjNkpdfrniF3pvYQAXwxVB7afhmsgzYtSCzTVZQ3F5SPHzP5PuHgtBGNYucZTSrnA7yTTDr7WGQZaTTkJWfiH47jW5ahU
+          did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9
+          did:key:z82LkvCwHNreneWpsgPEbV3gu1C6NFJEBg4srfJ5gdxEsMGRJUz2sG9FE42shbn2xkZJh54
         </pre>
       </section>
 
       <section class="informative">
         <h3>P-521</h2>
-          <p>These DID always start with <code>zWG</code>.</p>
+          <p>These DID always start with <code>z2J9</code>.</p>
         <pre class="example">
-          did:key:zWGhj2NTyCiehTPioanYSuSrfB7RJKwZj6bBUDNojfGEA21nr5NcBsHme7hcVSbptpWKarJpTcw814J3X8gVU9gZmeKM27JpGA5wNMzt8JZwjDyf8EzCJg5ve5GR2Xfm7d9Djp73V7s35KPeKe7VHMzmL8aPw4XBniNej5sXapPFoBs5R8m195HK
-          did:key:zWGhiwzmESrRykvUMCSNCadMyhzgAMVXST3KLSxY5unckUdYaGBZs59WMkMggeenMFAr938YxbEesbQ7myxmqDYo3m7xgFu8ppYDx2waz2Lw6eD9aADLn6Cw6Q6gTrH6sry211Z16nvVW25dsY6bZKhGKt4DeB1gGfvBk8bxwKuxTUtZrgwrMm1S
+          did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7
+          did:key:z2J9gcGdb2nEyMDmzQYv2QZQcM1vXktvy1Pw4MduSWxGabLZ9XESSWLQgbuPhwnXN7zP7HpTzWqrMTzaY5zWe6hpzJ2jnw4f
         </pre>
       </section>
 


### PR DESCRIPTION
Update `index.html` to match the test vectors updated in #36.

To find the "always start with" strings (ASCII prefixes for the key type), I used the following code to output the lowest and highest possible values.
<details>
<summary>Finding low and high values for string encoding</summary>

##### `package.json`
```json
{
  "dependencies": {
    "bs58": "^4.0.1",
    "multicodec": "^3.0.1"
  }
}
```

##### `index.js`
```js
const multicodec = require('multicodec')
const bs58 = require('bs58')

const p1 = multicodec.getVarintFromName('p256-pub')
const p2 = multicodec.getVarintFromName('p384-pub')
const p3 = multicodec.getVarintFromName('p521-pub')

console.log('256')
console.log('z' + bs58.encode(Buffer.concat([p1, Buffer.from([3]), Buffer.alloc(32)])))
console.log('z' + bs58.encode(Buffer.concat([p1, Buffer.from([4]), Buffer.alloc(32).fill(0xff)])))

console.log('384')
console.log('z' + bs58.encode(Buffer.concat([p2, Buffer.from([3]), Buffer.alloc(48)])))
console.log('z' + bs58.encode(Buffer.concat([p2, Buffer.from([4]), Buffer.alloc(48).fill(0xff)])))

console.log('521')
console.log('z' + bs58.encode(Buffer.concat([p3, Buffer.from([3]), Buffer.alloc(66)])))
console.log('z' + bs58.encode(Buffer.concat([p3, Buffer.from([4]), Buffer.alloc(66).fill(0xff)])))
```

Output:
```
256
zDnaehfHR8Q5U7ckmLQfuZ3eGEypooJ46zzjRQ1AR9asDvdnw
zDnafJ7vA7yafhiEJUaEk1PzrdRRrJHLkVQscN754sRikxYHU
384
z82LkuunYkEaW6hnkwZoenagXUavk3RVEbwXBCFtxfxVSX4PXWp8RvfGuqMZi2Y1seKhBRh
z82LmEh7HuG6tdmiDieQBvU7B7qxpWNyTbram9E8FDChZPJD2HP21Ejm968VqYDH1zW8zVU
521
z2J9gcGEGou6jrLk1mjqfd44NoDu2r2rktFi5Zpui3zDmFnaKeZwnjHwg1YwEaX9Y3gUpDohvPhW8zmpZBBV281UfXfSc1Wf
z2J9gfheqNuXb3kUexfMSSsBXuyVnANQgS1MMdw8gYnMeffnRzXLLZbgjhFnvMn1W1fWitCE7BWUpXRAmnfDVc23eUAG1gHL
```

Longest common prefixes: `zDNa`, `z82Lm`, and `z2J9g`.
</details>