### PR TITLE
Add normative statements for DID Document creation algorithm.

### DIFF
--- a/common.js
+++ b/common.js
@@ -172,6 +172,20 @@ var ccg = {
       authors: ['Gregg Kellogg', 'Manu Sporny', 'Dave Longley', 'Markus Lanthaler', 'Pierre-Antoine Champin', 'Niklas Lindström'],
       status: 'WD',
       publisher: 'W3C JSON-LD 1.1 Working Group'
+    },
+    'THORMARKER': {
+      title: 'On using the same key pair for Ed25519 and an X25519 based KEM',
+      href: 'https://eprint.iacr.org/2021/509.pdf',
+      authors: ['Erik Thormarker'],
+      status: 'Internet-Draft',
+      publisher: 'Cryptology ePrint Archive'
+    },
+    'OSCORE': {
+      title: 'Group OSCORE - Secure Group Communication for CoAP',
+      href: 'https://datatracker.ietf.org/doc/html/draft-ietf-core-oscore-groupcomm',
+      authors: ['M. Tiloca', 'G. Selander', 'F. Palombini', 'J. Mattsson', 'J. Park'],
+      status: 'Internet-Draft',
+      publisher: 'Internet Engineering Task Force (IETF)'
     }
   }
 };

--- a/index.html
+++ b/index.html
@@ -276,7 +276,9 @@ associated DID Document:
 The following algorithm can be used for expanding a did:key identifier to a DID
 Document. An <em>identifier</em> and <em>options</em> are the required inputs.
 Implementations are expected to set a reasonable default for the
-<em>options</em> `type` value such as `JsonWebKey2020` or `Multikey`.
+<em>options</em> `type` value such as `JsonWebKey2020` or `Multikey`. The
+<em>options</em> `enableExperimentalPublicKeyTypes` value SHOULD be set to
+`false`. Defaults MAY be overridden by the caller of this algorithm.
 A <em>document</em> is the resulting output.
           </p>
 
@@ -425,7 +427,7 @@ If <em>key encoding type</em> is not known to the implementation, an
 UNSUPPORTED_PUBLIC_KEY_TYPE error MUST be raised.
             </li>
             <li>
-If <em>options</em> `allowExperimentalPublicKeyTypes` is not set to `true` and
+If <em>options</em> `enableExperimentalPublicKeyTypes` is set to `false` and
 <em>key encoding type</em> is not `Multikey`, `JsonWebKey2020`, or
 `Ed25519VerificationKey2020`, an INVALID_PUBLIC_KEY_TYPE error MUST be raised.
             </li>
@@ -558,7 +560,7 @@ If <em>key encoding type</em> is not known to the implementation, an
 UNSUPPORTED_PUBLIC_KEY_TYPE error MUST be raised.
             </li>
             <li>
-If <em>options</em> `allowExperimentalPublicKeyTypes` is not set to `true` and
+If <em>options</em> `enableExperimentalPublicKeyTypes` is set to `false` and
 <em>key encoding type</em> is not `Multikey`, `JsonWebKey2020`, or
 `X25519KeyAgreementKey2020`, an INVALID_PUBLIC_KEY_TYPE error MUST be raised.
             </li>

--- a/index.html
+++ b/index.html
@@ -306,11 +306,6 @@ Initialize the <em>signatureVerificationMethod</em> to the result of passing
 <a href="#signature-method-creation-algorithm"></a>.
             </li>
             <li>
-Initialize the <em>encryptionVerificationMethod</em> to the result of passing
-<em>identifier</em>, <em>multibaseValue</em>, and <em>options</em> to
-<a href="#encryption-method-creation-algorithm"></a>.
-            </li>
-            <li>
 Set <em>document.id</em> to <em>identifier</em>. If <em>document.id</em> is not
 a valid DID, an INVALID_DID error MUST be raised.
             </li>
@@ -325,11 +320,23 @@ where the first item is the value of the `id` property in
 <em>signatureVerificationMethod</em>.
             </li>
             <li>
-If <em>options.disableKeyAgreement</em> is not set to `true`,
-add the <em>encryptionVerificationMethod</em> value to the
-`verificationMethod` array and initialize the `keyAgreement` property in
-<em>document</em> to an array where the first item is the value of the `id`
-property in <em>encryptionVerificationMethod</em>.
+If <em>options.enableEncryptionKeyDerivation</em> is set to `true`:
+              <ol class="algorithm">
+                <li>
+Initialize the <em>encryptionVerificationMethod</em> to the result of passing
+<em>identifier</em>, <em>multibaseValue</em>, and <em>options</em> to
+<a href="#encryption-method-creation-algorithm"></a>.
+                </li>
+                <li>
+Add the <em>encryptionVerificationMethod</em> value to the `verificationMethod`
+array.
+                </li>
+                <li>
+Initialize the `keyAgreement` property in <em>document</em> to an array where
+the first item is the value of the `id` property in
+<em>encryptionVerificationMethod</em>.
+                </li>
+              </ol>
             </li>
             <li>
 Return <em>document</em>.

--- a/index.html
+++ b/index.html
@@ -113,6 +113,9 @@ pre .comment {
   font-weight: bold;
   text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
 }
+ol.algorithm { counter-reset:numsection; list-style-type: none; }
+ol.algorithm li { margin: 0.5em 0; }
+ol.algorithm li:before { font-weight: bold; counter-increment: numsection; content: counters(numsection, ".") ") "; }
     </style>
   </head>
   <body>
@@ -265,6 +268,100 @@ associated DID Document:
             "keyAgreement": ["did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#z6LSni4ALZW58RuBPizpNeTK3HGfZfSuE3zcxeBubnrssYuh"]
           }
         </pre>
+
+        <section class="normative">
+          <h4>Expansion Algorithm</h4>
+
+          <p>
+The following algorithm can be used for expanding a did:key identifier to a DID
+Document. An <em>identifier</em> and <em>options</em> are the required inputs. A
+<em>document</em> is the resulting output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize <em>document</em> to an empty object.
+            </li>
+            <li>
+Using a colon (`:`) as the delimiter, split the <em>identifier</em> into its
+components: a <em>scheme</em>, a <em>method</em>, a <em>version</em>, and a
+<em>multibase value</em>. If there are only three components set the
+<em>version</em> to the string value `1` and use the last value as the
+<em>multibase value</em>.
+            </li>
+            <li>
+Check the validity of the input <em>identifier</em>. The <em>scheme</em> MUST be
+the value `did`. The <em>method</em> MUST be the value `key`. The
+<em>version</em> MUST be convertible to a positive integer value. The
+<em>multibase value</em> MUST be a string and begin with the letter `z`. If any
+of these requirements fail, an INVALID_DID error MUST be raised.
+            </li>
+            <li>
+Decode <em>multibase value</em> using the base58-btc multibase alphabet and set
+<em>multicodec value</em> to the multicodec header for the decoded value and
+the <em>raw public key bytes</em> to the bytes remaining after the multicodec
+header. Implementers are cautioned to ensure that <em>multicodec value</em>
+is set to the result after performing varint decoding.
+            </li>
+            <li>
+Initialize the <em>signature verification method</em> to the result of passing
+<em>options</em> to the <a href="#signature-method-expansion-algorithm"></a>.
+            </li>
+            <li>
+Initialize the <em>encryption verification method</em> to the result of passing
+<em>options</em> to the <a href="#encryption-method-expansion-algorithm"></a>.
+            </li>
+            <li>
+Set the `id` property in <em>document</em> to <em>identifier</em>.
+            </li>
+            <li>
+Initialize the `verificationMethod` property in <em>document</em> to an array
+where the first value is the <em>signature verification method</em> and the
+second value is the <em>encryption verification method</em>.
+            </li>
+            <li>
+Initialize the `authentication` property in <em>document</em> to an array
+where the first item is the value of he `id` property in
+<em>signature verification method</em>.
+            </li>
+            <li>
+Initialize the `assertionMethod` property in <em>document</em> to an array
+where the first item is the value of he `id` property in
+<em>signature verification method</em>.
+            </li>
+            <li>
+Initialize the `capabilityInvocation` property in <em>document</em> to an array
+where the first item is the value of he `id` property in
+<em>signature verification method</em>.
+            </li>
+            <li>
+Initialize the `capabilityDelegation` property in <em>document</em> to an array
+where the first item is the value of he `id` property in
+<em>signature verification method</em>.
+            </li>
+            <li>
+Initialize the `keyAgreement` property in <em>document</em> to an array
+where the first item is the value of he `id` property in
+<em>encryption verification method</em>.
+            </li>
+            <li>
+Return <em>document</em>.
+            </li>
+          </ol>
+          <p>
+Any alternative algorithm can be used that produces an equivalent result to the
+output from the algorithm above.
+          </p>
+        </section>
+
+        <section class="normative">
+          <h4>Signature Method Expansion Algorithm</h4>
+        </section>
+
+        <section class="normative">
+          <h4>Encryption Method Expansion Algorithm</h4>
+        </section>
+
       </section>
 
       <section class="normative">
@@ -299,7 +396,7 @@ This DID Method does not support deactivating the DID Document.
       <h2>Test Vectors</h2>
       <!-- No way to do directory listing on github pages short of generating them client side :-(  Not sure if there's a better way to do this -->
       <p>For a full list of test vectors see <a href="https://github.com/w3c-ccg/did-method-key/tree/master/test-vectors">test vectors</a>.</p>
-      
+
       <section class="informative">
         <h3>Ed25519 / X25519</h3>
           <p>These DID always start with <code>z6Mk</code>.</p>

--- a/index.html
+++ b/index.html
@@ -436,6 +436,20 @@ public key length for the associated <em>multicodecValue</em>, an
 INVALID_PUBLIC_KEY_LENGTH error MUST be raised.
             </li>
             <li>
+Ensure the <em>rawPublicKeyBytes</em> are a proper encoding of the public key
+type as specified by the <em>multicodecValue</em>. This validation is often
+done by a cryptographic library when importing the public key by, for example,
+ensuring that an Elliptic Curve public key is a specific coordinate that exists
+on the elliptic curve. If an invalid public key value is detected, an
+INVALID_PUBLIC_KEY error MUST be raised.
+
+<div class="issue" title="Request for feedback on implementability">
+It is not clear if this particular check is implementable across all public
+key types. The group is accepting feedback on the implementability of this
+particular feature.
+</div>
+            </li>
+            <li>
 Set the <em>verificationMethod.id</em> value by concatenating
 <em>identifier</em>, a hash character (`#`), and the <em>multicodecValue</em>.
 If <em>verificationMethod.id</em> is not a valid DID URL, an INVALID_DID_URL

--- a/index.html
+++ b/index.html
@@ -276,8 +276,8 @@ associated DID Document:
 The following algorithm can be used for expanding a did:key identifier to a DID
 Document. An <em>identifier</em> and <em>options</em> are the required inputs.
 Implementations are expected to set a reasonable default for the
-<em>options</em> `publicKeyFormat` value such as `JsonWebKey2020` or `Multikey`. The
-<em>options</em> `enableExperimentalPublicKeyTypes` value SHOULD be set to
+<em>options.publicKeyFormat</em> value such as `JsonWebKey2020` or `Multikey`. The
+<em>options.enableExperimentalPublicKeyTypes</em> value SHOULD be set to
 `false`. Defaults MAY be overridden by the caller of this algorithm.
 A <em>document</em> is the resulting output.
           </p>
@@ -289,25 +289,25 @@ Initialize <em>document</em> to an empty object.
             <li>
 Using a colon (`:`) as the delimiter, split the <em>identifier</em> into its
 components: a <em>scheme</em>, a <em>method</em>, a <em>version</em>, and a
-<em>multibase value</em>. If there are only three components set the
+<em>multibaseValue</em>. If there are only three components set the
 <em>version</em> to the string value `1` and use the last value as the
-<em>multibase value</em>.
+<em>multibaseValue</em>.
             </li>
             <li>
 Check the validity of the input <em>identifier</em>. The <em>scheme</em> MUST be
 the value `did`. The <em>method</em> MUST be the value `key`. The
 <em>version</em> MUST be convertible to a positive integer value. The
-<em>multibase value</em> MUST be a string and begin with the letter `z`. If any
+<em>multibaseValue</em> MUST be a string and begin with the letter `z`. If any
 of these requirements fail, an INVALID_DID error MUST be raised.
             </li>
             <li>
-Initialize the <em>signature verification method</em> to the result of passing
-<em>identifier</em>, <em>multibase value</em>, and <em>options</em> to
+Initialize the <em>signatureVerificationMethod</em> to the result of passing
+<em>identifier</em>, <em>multibaseValue</em>, and <em>options</em> to
 <a href="#signature-method-creation-algorithm"></a>.
             </li>
             <li>
-Initialize the <em>encryption verification method</em> to the result of passing
-<em>identifier</em>, <em>multibase value</em>, and <em>options</em> to
+Initialize the <em>encryptionVerificationMethod</em> to the result of passing
+<em>identifier</em>, <em>multibaseValue</em>, and <em>options</em> to
 <a href="#encryption-method-creation-algorithm"></a>.
             </li>
             <li>
@@ -315,20 +315,20 @@ Set the `id` property in <em>document</em> to <em>identifier</em>.
             </li>
             <li>
 Initialize the `verificationMethod` property in <em>document</em> to an array
-where the first value is the <em>signature verification method</em>.
+where the first value is the <em>signatureVerificationMethod</em>.
             </li>
             <li>
 Initialize the `authentication`, `assertionMethod`, `capabilityInvocation`,
 and the `capabilityDelegation` property in <em>document</em> to an array
 where the first item is the value of the `id` property in
-<em>signature verification method</em>.
+<em>signatureVerificationMethod</em>.
             </li>
             <li>
-If <em>options</em> `disableKeyAgreement` is not set to `true`,
-add the <em>encryption verification method</em> value to the
+If <em>options.disableKeyAgreement</em> is not set to `true`,
+add the <em>encryptionVerificationMethod</em> value to the
 `verificationMethod` array and initialize the `keyAgreement` property in
 <em>document</em> to an array where the first item is the value of the `id`
-property in <em>encryption verification method</em>.
+property in <em>encryptionVerificationMethod</em>.
             </li>
             <li>
 Return <em>document</em>.
@@ -346,23 +346,23 @@ output from the algorithm above.
           <p>
 The following algorithm can be used for decoding a multibase-encoded multicodec
 value into a verification method that is suitable for verifying digital
-signatures. An <em>identifier</em>, <em>multibase value</em>, and
-<em>options</em> are the required inputs. A <em>verification method</em> is
+signatures. An <em>identifier</em>, <em>multibaseValue</em>, and
+<em>options</em> are the required inputs. A <em>verificationMethod</em> is
 the resulting output.
           </p>
 
           <ol class="algorithm">
             <li>
-Initialize <em>verification method</em> to an empty object.
+Initialize <em>verificationMethod</em> to an empty object.
             </li>
             <li>
-Set <em>multicodec value</em> and <em>raw public key bytes</em> to the result
-of passing <em>multibase value</em> and <em>options</em> to
+Set <em>multicodecValue</em> and <em>rawPublicKeyBytes</em> to the result
+of passing <em>multibaseValue</em> and <em>options</em> to
 <a href="#decode-public-key-algorithm"></a>.
             </li>
             <li>
-Ensure the proper key length of <em>raw public key bytes</em> based on the
-<em>multicodec value</em> table provided below:
+Ensure the proper key length of <em>rawPublicKeyBytes</em> based on the
+<em>multicodecValue</em> table provided below:
               <table class="simple">
                 <thead>
                   <th>Multicodec hexadecimal value</th>
@@ -411,45 +411,45 @@ IETF RFC 8017 (PKCS #1)
                   </tr>
                 </tbody>
               </table>
-If the byte length of <em>raw public key bytes</em> does not match the expected
-public key length for the associated <em>multicodec value</em>, an
+If the byte length of <em>rawPublicKeyBytes</em> does not match the expected
+public key length for the associated <em>multicodecValue</em>, an
 INVALID_PUBLIC_KEY_LENGTH error MUST be raised.
             </li>
             <li>
-Set the <em>verification method</em> `id` value by concatenating
-<em>identifier</em>, a hash character (`#`), and the <em>multicodec value</em>.
+Set the <em>verificationMethod.id</em> value by concatenating
+<em>identifier</em>, a hash character (`#`), and the <em>multicodecValue</em>.
             </li>
             <li>
-Set the <em>key encoding type</em> value to the <em>options</em>
-`publicKeyFormat` value.
+Set the <em>publicKeyFormat</em> value to the <em>options.publicKeyFormat</em>
+value.
             </li>
             <li>
-If <em>key encoding type</em> is not known to the implementation, an
+If <em>publicKeyFormat</em> is not known to the implementation, an
 UNSUPPORTED_PUBLIC_KEY_TYPE error MUST be raised.
             </li>
             <li>
-If <em>options</em> `enableExperimentalPublicKeyTypes` is set to `false` and
-<em>key encoding type</em> is not `Multikey`, `JsonWebKey2020`, or
+If <em>options.enableExperimentalPublicKeyTypes</em> is set to `false` and
+<em>publicKeyFormat</em> is not `Multikey`, `JsonWebKey2020`, or
 `Ed25519VerificationKey2020`, an INVALID_PUBLIC_KEY_TYPE error MUST be raised.
             </li>
             <li>
-Set the <em>verification method</em> `type` to the <em>key encoding type</em>.
+Set <em>verificationMethod.type</em> to the <em>publicKeyFormat</em> value.
             </li>
             <li>
-Set the <em>verification method</em> `controller` to <em>identifier</em>.
+Set <em>verificationMethod.controller</em> to the <em>identifier</em> value.
             </li>
             <li>
-If <em>key encoding type</em> is `Multikey` or `Ed25519VerificationKey2020`,
-set the <em>verification method</em> `publicKeyMultibase` value to
-<em>multibase value</em>.
+If <em>publicKeyFormat</em> is `Multikey` or `Ed25519VerificationKey2020`,
+set the <em>verificationMethod.publicKeyMultibase</em> value to
+<em>multibaseValue</em>.
             <li>
-If <em>key encoding type</em> is `JsonWebKey2020`, set the
-<em>verification method</em> `publicKeyJwk` value to the result of
-passing <em>multicodec value</em> and <em>raw public key bytes</em> to
+If <em>publicKeyFormat</em> is `JsonWebKey2020`, set the
+<em>verificationMethod.publicKeyJwk</em> value to the result of
+passing <em>multicodecValue</em> and <em>rawPublicKeyBytes</em> to
 <a href="#encode-jwk-algorithm"></a>.
             </li>
             <li>
-Return <em>verification method</em>.
+Return <em>verificationMethod</em>.
             </li>
           </ol>
 
@@ -460,28 +460,28 @@ Return <em>verification method</em>.
 
           <p>
 The following algorithm can be used for expanding a multibase-encoded
-multicodec value to decoded public key components. A <em>multibase value</em>
-and <em>options</em> are the required inputs. A <em>decoded public key</em> is
+multicodec value to decoded public key components. A <em>multibaseValue</em>
+and <em>options</em> are the required inputs. A <em>decodedPublicKey</em> is
 the output.
           </p>
 
           <ol class="algorithm">
             <li>
-Set <em>decoded public key</em> to an empty object.
+Set <em>decodedPublicKey</em> to an empty object.
             </li>
             <li>
-Decode <em>multibase value</em> using the base58-btc multibase alphabet and set
-<em>multicodec value</em> to the multicodec header for the decoded value.
-Implementers are cautioned to ensure that the <em>multicodec value</em>
+Decode <em>multibaseValue</em> using the base58-btc multibase alphabet and set
+<em>multicodecValue</em> to the multicodec header for the decoded value.
+Implementers are cautioned to ensure that the <em>multicodecValue</em>
 is set to the result after performing varint decoding.
             </li>
             <li>
-Set the <em>raw public key bytes</em> to the bytes remaining after the
+Set the <em>rawPublicKeyBytes</em> to the bytes remaining after the
 multicodec header.
             </li>
             <li>
-Return <em>multicodec value</em> and <em>raw public key bytes</em> as the
-<em>decoded public key</em>.
+Return <em>multicodecValue</em> and <em>rawPublicKeyBytes</em> as the
+<em>decodedPublicKey</em>.
             </li>
           </ol>
         </section>
@@ -491,8 +491,8 @@ Return <em>multicodec value</em> and <em>raw public key bytes</em> as the
 
           <p>
 The following algorithm can be used to encode a multicodec value to a
-JSON Web Key. A <em>multicodec value</em>, <em>raw public key bytes</em>,
-and <em>options</em> are the required inputs. An <em>encoded JWK</em> is
+JSON Web Key. A <em>multicodecValue</em>, <em>rawPublicKeyBytes</em>,
+and <em>options</em> are the required inputs. An <em>encodedJWK</em> is
 the output.
           </p>
 
@@ -509,23 +509,23 @@ to the JSON Web Key format.
 The following algorithm can be used for decoding a multibase-encoded multicodec
 value into a verification method that is suitable for verifying that
 encrypted information will be received by the intended recipient. An
-<em>identifier</em>, <em>multibase value</em>, and
-<em>options</em> are the required inputs. A <em>verification method</em> is
+<em>identifier</em>, <em>multibaseValue</em>, and
+<em>options</em> are the required inputs. A <em>verificationMethod</em> is
 the resulting output.
           </p>
 
           <ol class="algorithm">
             <li>
-Initialize <em>verification method</em> to an empty object.
+Initialize <em>verificationMethod</em> to an empty object.
             </li>
             <li>
-Set <em>multicodec value</em> and <em>raw public key bytes</em> to the result
-of passing <em>multibase value</em> and <em>options</em> to
+Set <em>multicodecValue</em> and <em>rawPublicKeyBytes</em> to the result
+of passing <em>multibaseValue</em> and <em>options</em> to
 <a href="#derive-encryption-key-algorithm"></a>.
             </li>
             <li>
-Ensure the proper key length of <em>raw public key bytes</em> based on the
-<em>multicodec value</em> table provided below:
+Ensure the proper key length of <em>rawPublicKeyBytes</em> based on the
+<em>multicodecValue</em> table provided below:
               <table class="simple">
                 <thead>
                   <th>Multicodec hexadecimal value</th>
@@ -540,50 +540,50 @@ Ensure the proper key length of <em>raw public key bytes</em> based on the
                   </tr>
                 </tbody>
               </table>
-If the byte length of <em>raw public key bytes</em> does not match the expected
-public key length for the associated <em>multicodec value</em>, an
+If the byte length of <em>rawPublicKeyBytes</em> does not match the expected
+public key length for the associated <em>multicodecValue</em>, an
 INVALID_PUBLIC_KEY_LENGTH error MUST be raised.
             </li>
             <li>
-Create the <em>multibase value</em> by concatenating the letter 'z' and the
-base58-btc encoding of the concatenation of the <em>multicodec value</em> and
-the <em>raw public key bytes</em>.
+Create the <em>multibaseValue</em> by concatenating the letter 'z' and the
+base58-btc encoding of the concatenation of the <em>multicodecValue</em> and
+the <em>rawPublicKeyBytes</em>.
             </li>
             <li>
-Set the <em>verification method</em> `id` value by concatenating
-<em>identifier</em>, a hash character (`#`), and the <em>multibase value</em>.
+Set the <em>verificationMethod.id</em> value by concatenating
+<em>identifier</em>, a hash character (`#`), and the <em>multibaseValue</em>.
             </li>
             <li>
-Set the <em>key encoding type</em> value to the <em>options</em>
-`publicKeyFormat` value.
+Set the <em>publicKeyFormat</em> value to the <em>options.publicKeyFormat</em>
+value.
             </li>
             <li>
-If <em>key encoding type</em> is not known to the implementation, an
+If <em>publicKeyFormat</em> is not known to the implementation, an
 UNSUPPORTED_PUBLIC_KEY_TYPE error MUST be raised.
             </li>
             <li>
-If <em>options</em> `enableExperimentalPublicKeyTypes` is set to `false` and
-<em>key encoding type</em> is not `Multikey`, `JsonWebKey2020`, or
+If <em>options.enableExperimentalPublicKeyTypes</em> is set to `false` and
+<em>publicKeyFormat</em> is not `Multikey`, `JsonWebKey2020`, or
 `X25519KeyAgreementKey2020`, an INVALID_PUBLIC_KEY_TYPE error MUST be raised.
             </li>
             <li>
-Set the <em>verification method</em> `type` to the <em>key encoding type</em>.
+Set <em>verificationMethod.type</em> to the <em>publicKeyFormat</em> value.
             </li>
             <li>
-Set the <em>verification method</em> `controller` to <em>identifier</em>.
+Set <em>verificationMethod.controller</em> to <em>identifier</em>.
             </li>
             <li>
-If <em>key encoding type</em> is `Multikey` or `X25519KeyAgreementKey2020`,
-set the <em>verification method</em> `publicKeyMultibase` value to
-<em>multibase value</em>.
+If <em>publicKeyFormat</em> is `Multikey` or `X25519KeyAgreementKey2020`,
+set the <em>verificationMethod.publicKeyMultibase</em> value to
+<em>multibaseValue</em>.
             <li>
-If <em>key encoding type</em> is `JsonWebKey2020`, set the
-<em>verification method</em> `publicKeyJwk` value to the result of
-passing <em>multicodec value</em> and <em>raw public key bytes</em> to
+If <em>publicKeyFormat</em> is `JsonWebKey2020`, set the
+<em>verificationMethod.publicKeyJwk</em> value to the result of
+passing <em>multicodecValue</em> and <em>rawPublicKeyBytes</em> to
 <a href="#encode-jwk-algorithm"></a>.
             </li>
             <li>
-Return <em>verification method</em>.
+Return <em>verificationMethod</em>.
             </li>
           </ol>
 
@@ -593,44 +593,44 @@ Return <em>verification method</em>.
           <h4>Derive Encryption Key Algorithm</h4>
 
           <p>
-The following algorithm can be used to transform a multibase-encoded
-multicodec value to public encryption key components that are suitable for
-encrypting messages to a receiver. A mathematical proof elaborating on the
-safety of performing this operation is available in [[THORMARKER]]. A <em>multibase value</em> and
-<em>options</em> are the required inputs. A <em>public encryption key</em> is
-the output.
+The following algorithm can be used to transform a multibase-encoded multicodec
+value to public encryption key components that are suitable for encrypting
+messages to a receiver. A mathematical proof elaborating on the safety of
+performing this operation is available in [[THORMARKER]]. A
+<em>multibaseValue</em> and <em>options</em> are the required inputs. A
+<em>publicEncryptionKey</em> is the output.
           </p>
 
           <ol class="algorithm">
             <li>
-Set <em>public encryption key</em> to an empty object.
+Set <em>publicEncryptionKey</em> to an empty object.
             </li>
             <li>
-Decode <em>multibase value</em> using the base58-btc multibase alphabet and set
-<em>multicodec value</em> to the multicodec header for the decoded value.
-Implementers are cautioned to ensure that the <em>multicodec value</em>
+Decode <em>multibaseValue</em> using the base58-btc multibase alphabet and set
+<em>multicodecValue</em> to the multicodec header for the decoded value.
+Implementers are cautioned to ensure that the <em>multicodecValue</em>
 is set to the result after performing varint decoding.
             </li>
             <li>
-Set the <em>raw public key bytes</em> to the bytes remaining after the
+Set the <em>rawPublicKeyBytes</em> to the bytes remaining after the
 multicodec header.
             </li>
             <li>
-If the <em>multicodec value</em> is `0xed`, derive a public X25519 encryption
-key by using the <em>raw public key bytes</em> and the
+If the <em>multicodecValue</em> is `0xed`, derive a public X25519 encryption
+key by using the <em>rawPublicKeyBytes</em> and the
 algorithm defined in [[OSCORE]] for Curve25519 in
 Section 2.4.2: ECDH with Montgomery Coordinates and set
-<em>generated public encryption key bytes</em> to the result.
+<em>generatedPublicEncryptionKeyBytes</em> to the result.
             </li>
             <li>
-Set <em>multicodec value</em> in <em>public encryption key</em> to `0xec`.
+Set <em>multicodecValue</em> in <em>publicEncryptionKey</em> to `0xec`.
             </li>
             <li>
-Set <em>raw public key bytes</em> in <em>public encryption key</em> to
-<em>generated public encryption key bytes</em>.
+Set <em>rawPublicKeyBytes</em> in <em>publicEncryptionKey</em> to
+<em>generatedPublicEncryptionKeyBytes</em>.
             </li>
             <li>
-Return <em>public encryption key</em>.
+Return <em>publicEncryptionKey</em>.
             </li>
           </ol>
         </section>

--- a/index.html
+++ b/index.html
@@ -320,23 +320,9 @@ where the first value is the <em>signature verification method</em> and the
 second value is the <em>encryption verification method</em>.
             </li>
             <li>
-Initialize the `authentication` property in <em>document</em> to an array
-where the first item is the value of he `id` property in
-<em>signature verification method</em>.
-            </li>
-            <li>
-Initialize the `assertionMethod` property in <em>document</em> to an array
-where the first item is the value of he `id` property in
-<em>signature verification method</em>.
-            </li>
-            <li>
-Initialize the `capabilityInvocation` property in <em>document</em> to an array
-where the first item is the value of he `id` property in
-<em>signature verification method</em>.
-            </li>
-            <li>
-Initialize the `capabilityDelegation` property in <em>document</em> to an array
-where the first item is the value of he `id` property in
+Initialize the `authentication`, `assertionMethod`, `capabilityInvocation`,
+and the `capabilityDelegation` property in <em>document</em> to an array
+where the first item is the value of the `id` property in
 <em>signature verification method</em>.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -693,9 +693,9 @@ Set <em>contextArray</em> to an array that is initialized to
 <em>options.defaultContext</em>.
             </li>
             <li>
-For every object in <em>document.verificationMethod</em>, add a string value
-to the <em>contextArray</em> based on the object `type` value, according to
-the following table:
+For every object in every verification relationship listed in <em>document</em>,
+add a string value to the <em>contextArray</em> based on the object `type`
+value, if it doesn't already exist, according to the following table:
               <table class="simple">
                 <thead>
                   <th>`type` value</th>

--- a/index.html
+++ b/index.html
@@ -235,7 +235,7 @@ and encoding the public key using the format provided in  Section <a
 href="#format"></a>. The creation of a DID Document is also performed by taking
 the public key value and expanding it into DID Document. An example is given
 below that expands the ed25519 <tt>did:key</tt>
-<code>did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH</code> into its
+<code>did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2</code> into its
 associated DID Document:
         </p>
 

--- a/index.html
+++ b/index.html
@@ -311,8 +311,7 @@ Set the `id` property in <em>document</em> to <em>identifier</em>.
             </li>
             <li>
 Initialize the `verificationMethod` property in <em>document</em> to an array
-where the first value is the <em>signature verification method</em> and the
-second value is the <em>encryption verification method</em>.
+where the first value is the <em>signature verification method</em>.
             </li>
             <li>
 Initialize the `authentication`, `assertionMethod`, `capabilityInvocation`,
@@ -321,9 +320,11 @@ where the first item is the value of the `id` property in
 <em>signature verification method</em>.
             </li>
             <li>
-Initialize the `keyAgreement` property in <em>document</em> to an array
-where the first item is the value of the `id` property in
-<em>encryption verification method</em>.
+If <em>options</em> `disableKeyAgreement` is not set to `true`,
+add the <em>encryption verification method</em> value to the
+`verificationMethod` array and initialize the `keyAgreement` property in
+<em>document</em> to an array where the first item is the value of the `id`
+property in <em>encryption verification method</em>.
             </li>
             <li>
 Return <em>document</em>.

--- a/index.html
+++ b/index.html
@@ -576,6 +576,51 @@ Return <em>verification method</em>.
 
         </section>
 
+        <section class="normative">
+          <h4>Derive Encryption Key Algorithm</h4>
+
+          <p>
+The following algorithm can be used to transform a multibase-encoded
+multicodec value to public encryption key components that are suitable for
+encrypting messages to a receiver. A <em>multibase value</em> and
+<em>options</em> are the required inputs. A <em>public encryption key</em> is
+the output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Set <em>public encryption key</em> to an empty object.
+            </li>
+            <li>
+Decode <em>multibase value</em> using the base58-btc multibase alphabet and set
+<em>multicodec value</em> to the multicodec header for the decoded value.
+Implementers are cautioned to ensure that the <em>multicodec value</em>
+is set to the result after performing varint decoding.
+            </li>
+            <li>
+Set the <em>raw public key bytes</em> to the bytes remaining after the
+multicodec header.
+            </li>
+            <li>
+If the <em>multicodec value</em> is `0xed`, derive a public X25519 encryption
+key by using the <em>raw public key bytes</em> and the
+algorithm defined in [[OSCORE]] for Curve25519 in
+Section 2.4.2: ECDH with Montgomery Coordinates and set
+<em>generated public encryption key bytes</em> to the result.
+            </li>
+            <li>
+Set <em>multicodec value</em> in <em>public encryption key</em> to `0xec`.
+            </li>
+            <li>
+Set <em>raw public key bytes</em> in <em>public encryption key</em> to
+<em>generated public encryption key bytes</em>.
+            </li>
+            <li>
+Return <em>public encryption key</em>.
+            </li>
+          </ol>
+        </section>
+
       </section>
 
       <section class="normative">

--- a/index.html
+++ b/index.html
@@ -276,10 +276,12 @@ associated DID Document:
 The following algorithm can be used for expanding a did:key identifier to a DID
 Document. An <em>identifier</em> and <em>options</em> are the required inputs.
 Implementations are expected to set a reasonable default for the
-<em>options.publicKeyFormat</em> value such as `JsonWebKey2020` or `Multikey`. The
-<em>options.enableExperimentalPublicKeyTypes</em> value SHOULD be set to
-`false`. Defaults MAY be overridden by the caller of this algorithm.
-A <em>document</em> is the resulting output.
+<em>options.publicKeyFormat</em> value such as `JsonWebKey2020` or `Multikey`.
+The <em>options.enableExperimentalPublicKeyTypes</em> value SHOULD be set to
+`false`. The <em>options.defaultContext</em> value SHOULD be set to an array
+where the first element is the string value `https://www.w3.org/ns/did/v1`.
+Defaults MAY be overridden by the caller of this algorithm. A <em>document</em>
+is the resulting output.
           </p>
 
           <ol class="algorithm">
@@ -315,7 +317,7 @@ where the first value is the <em>signatureVerificationMethod</em>.
             </li>
             <li>
 Initialize the `authentication`, `assertionMethod`, `capabilityInvocation`,
-and the `capabilityDelegation` property in <em>document</em> to an array
+and the `capabilityDelegation` properties in <em>document</em> to an array
 where the first item is the value of the `id` property in
 <em>signatureVerificationMethod</em>.
             </li>
@@ -337,6 +339,11 @@ the first item is the value of the `id` property in
 <em>encryptionVerificationMethod</em>.
                 </li>
               </ol>
+            </li>
+            <li>
+Initialize the `@context` property in <em>document</em> to the result of
+passing <em>document</em> and <em>options</em> to the
+<a href="#context-creation-algorithm"></a>.
             </li>
             <li>
 Return <em>document</em>.
@@ -647,6 +654,65 @@ Set <em>rawPublicKeyBytes</em> in <em>publicEncryptionKey</em> to
             </li>
             <li>
 Return <em>publicEncryptionKey</em>.
+            </li>
+          </ol>
+        </section>
+
+        <section class="normative">
+          <h4>Context Creation Algorithm</h4>
+
+          <p>
+The following algorithm is used to generate the array for the `@context`
+property in the DID Document. A <em>document</em> and <em>options</em> are the
+required inputs. A <em>contextArray</em> is the output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Set <em>contextArray</em> to an array that is initialized to
+<em>options.defaultContext</em>.
+            </li>
+            <li>
+For every object in <em>document.verificationMethod</em>, add a string value
+to the <em>contextArray</em> based on the object `type` value, according to
+the following table:
+              <table class="simple">
+                <thead>
+                  <th>`type` value</th>
+                  <th>Context URL</th>
+                </thead>
+
+                <tbody>
+                  <tr>
+                    <td>`Ed25519VerificationKey2020`</td>
+                    <td>
+https://w3id.org/security/suites/ed25519-2020/v1
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>`X25519KeyAgreementKey2020`</td>
+                    <td>
+https://w3id.org/security/suites/x25519-2020/v1
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>`JsonWebKey2020`</td>
+                    <td>
+https://w3id.org/security/suites/jws-2020/v1
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>`Multikey`</td>
+                    <td class="issue">
+There is currently no JSON-LD Context that defines the Multikey type. This is
+expected to be defined by the VC2WG in 2022 or 2023.
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </li>
+            <li>
+Return <em>contextArray</em>.
             </li>
           </ol>
         </section>

--- a/index.html
+++ b/index.html
@@ -493,6 +493,89 @@ to the JSON Web Key format.
           </p>
         </section>
 
+        <section class="normative">
+          <h4>Encryption Method Creation Algorithm</h4>
+
+          <p>
+The following algorithm can be used for decoding a multibase-encoded multicodec
+value into a verification method that is suitable for verifying that
+encrypted information will be received by the intended recipient. An
+<em>identifier</em>, <em>multibase value</em>, and
+<em>options</em> are the required inputs. A <em>verification method</em> is
+the resulting output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize <em>verification method</em> to an empty object.
+            </li>
+            <li>
+Set <em>multicodec value</em> and <em>raw public key bytes</em> to the result
+of passing <em>multibase value</em> and <em>options</em> to
+<a href="#derive-encryption-key-algorithm"></a>.
+            </li>
+            <li>
+Ensure the proper key length of <em>raw public key bytes</em> based on the
+<em>multicodec value</em> table provided below:
+              <table class="simple">
+                <thead>
+                  <th>Multicodec hexadecimal value</th>
+                  <th>public key byte length</th>
+                  <th>Description</th>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>`0xec`</td>
+                    <td>32 bytes</td>
+                    <td>x25519-pub - Curve25519 public key</td>
+                  </tr>
+                </tbody>
+              </table>
+If the byte length of <em>raw public key bytes</em> does not match the expected
+public key length for the associated <em>multicodec value</em>, an
+INVALID_PUBLIC_KEY_LENGTH error MUST be raised.
+            </li>
+            <li>
+Create the <em>multibase value</em> by concatenating the letter 'z' and the
+base58-btc encoding of the concatenation of the <em>multicodec value</em> and
+the <em>raw public key bytes</em>.
+            </li>
+            <li>
+Set the <em>verification method</em> `id` value by concatenating
+<em>identifier</em>, a hash character (`#`), and the <em>multibase value</em>.
+            </li>
+            <li>
+Set the <em>key encoding type</em> value to the <em>options</em> `type` value
+if it is set, or `Multikey` if it is not set.
+            </li>
+            <li>
+If <em>options</em> `allowExperimentalPublicKeyTypes` is not set to `true` and
+<em>key encoding type</em> is not `Multikey`, `JsonWebKey2020`, or
+`X25519KeyAgreementKey2020`, an INVALID_PUBLIC_KEY_TYPE error MUST be raised.
+            </li>
+            <li>
+Set the <em>verification method</em> `type` to the <em>key encoding type</em>.
+            </li>
+            <li>
+Set the <em>verification method</em> `controller` to <em>identifier</em>.
+            </li>
+            <li>
+If <em>key encoding type</em> is `Multikey` or `X25519KeyAgreementKey2020`,
+set the <em>verification method</em> `publicKeyMultibase` value to
+<em>multibase value</em>.
+            <li>
+If <em>key encoding type</em> is `JsonWebKey2020`, set the
+<em>verification method</em> `publicKeyJwk` value to the result of
+passing <em>multicodec value</em> and <em>raw public key bytes</em> to
+<a href="#encode-jwk-algorithm"></a>.
+            </li>
+            <li>
+Return <em>verification method</em>.
+            </li>
+          </ol>
+
+        </section>
+
       </section>
 
       <section class="normative">

--- a/index.html
+++ b/index.html
@@ -583,7 +583,8 @@ Return <em>verification method</em>.
           <p>
 The following algorithm can be used to transform a multibase-encoded
 multicodec value to public encryption key components that are suitable for
-encrypting messages to a receiver. A <em>multibase value</em> and
+encrypting messages to a receiver. A mathematical proof elaborating on the
+safety of performing this operation is available in [[THORMARKER]]. A <em>multibase value</em> and
 <em>options</em> are the required inputs. A <em>public encryption key</em> is
 the output.
           </p>

--- a/index.html
+++ b/index.html
@@ -446,6 +446,36 @@ Return <em>verification method</em>.
 
         </section>
 
+        <section class="normative">
+          <h4>Decode Public Key Algorithm</h4>
+
+          <p>
+The following algorithm can be used for expanding a multibase-encoded
+multicodec value to decoded public key components. A <em>multibase value</em>
+and <em>options</em> are the required inputs. A <em>decoded public key</em> is
+the output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Set <em>decoded public key</em> to an empty object.
+            </li>
+            <li>
+Decode <em>multibase value</em> using the base58-btc multibase alphabet and set
+<em>multicodec value</em> to the multicodec header for the decoded value.
+Implementers are cautioned to ensure that the <em>multicodec value</em>
+is set to the result after performing varint decoding.
+            </li>
+            <li>
+Set the <em>raw public key bytes</em> to the bytes remaining after the
+multicodec header.
+            </li>
+            <li>
+Return <em>multicodec value</em> and <em>raw public key bytes</em> as the
+<em>decoded public key</em>.
+            </li>
+          </ol>
+        </section>
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -311,7 +311,8 @@ Initialize the <em>encryptionVerificationMethod</em> to the result of passing
 <a href="#encryption-method-creation-algorithm"></a>.
             </li>
             <li>
-Set the `id` property in <em>document</em> to <em>identifier</em>.
+Set <em>document.id</em> to <em>identifier</em>. If <em>document.id</em> is not
+a valid DID, an INVALID_DID error MUST be raised.
             </li>
             <li>
 Initialize the `verificationMethod` property in <em>document</em> to an array
@@ -418,6 +419,8 @@ INVALID_PUBLIC_KEY_LENGTH error MUST be raised.
             <li>
 Set the <em>verificationMethod.id</em> value by concatenating
 <em>identifier</em>, a hash character (`#`), and the <em>multicodecValue</em>.
+If <em>verificationMethod.id</em> is not a valid DID URL, an INVALID_DID_URL
+error MUST be raised.
             </li>
             <li>
 Set the <em>publicKeyFormat</em> value to the <em>options.publicKeyFormat</em>
@@ -437,6 +440,8 @@ Set <em>verificationMethod.type</em> to the <em>publicKeyFormat</em> value.
             </li>
             <li>
 Set <em>verificationMethod.controller</em> to the <em>identifier</em> value.
+If <em>verificationMethod.controller</em> is not a valid DID, an INVALID_DID
+error MUST be raised.
             </li>
             <li>
 If <em>publicKeyFormat</em> is `Multikey` or `Ed25519VerificationKey2020`,
@@ -552,6 +557,8 @@ the <em>rawPublicKeyBytes</em>.
             <li>
 Set the <em>verificationMethod.id</em> value by concatenating
 <em>identifier</em>, a hash character (`#`), and the <em>multibaseValue</em>.
+If <em>verificationMethod.id</em> is not a valid DID URL, an INVALID_DID_URL
+error MUST be raised.
             </li>
             <li>
 Set the <em>publicKeyFormat</em> value to the <em>options.publicKeyFormat</em>
@@ -570,7 +577,9 @@ If <em>options.enableExperimentalPublicKeyTypes</em> is set to `false` and
 Set <em>verificationMethod.type</em> to the <em>publicKeyFormat</em> value.
             </li>
             <li>
-Set <em>verificationMethod.controller</em> to <em>identifier</em>.
+Set <em>verificationMethod.controller</em> to <em>identifier</em>. If
+<em>verificationMethod.controller</em> is not a valid DID, an
+INVALID_DID error MUST be raised.
             </li>
             <li>
 If <em>publicKeyFormat</em> is `Multikey` or `X25519KeyAgreementKey2020`,

--- a/index.html
+++ b/index.html
@@ -408,7 +408,7 @@ Ensure the proper key length of <em>rawPublicKeyBytes</em> based on the
                   </tr>
                   <tr>
                     <td>`0x1201`</td>
-                    <td>?? bytes</td>
+                    <td>49 bytes</td>
                     <td>p384-pub - P-384 public key (compressed)</td>
                   </tr>
                   <tr>

--- a/index.html
+++ b/index.html
@@ -239,7 +239,8 @@ below that expands the ed25519 <tt>did:key</tt>
 associated DID Document:
         </p>
 
-        <pre class="example" title="An example of a did:key DID Document">
+        <pre class="example" title="An example of a did:key DID Document"
+        style="font-size: 0.65em;">
 {
   "@context": [
     "https://www.w3.org/ns/did/v1",

--- a/index.html
+++ b/index.html
@@ -276,7 +276,7 @@ associated DID Document:
 The following algorithm can be used for expanding a did:key identifier to a DID
 Document. An <em>identifier</em> and <em>options</em> are the required inputs.
 Implementations are expected to set a reasonable default for the
-<em>options</em> `type` value such as `JsonWebKey2020` or `Multikey`. The
+<em>options</em> `publicKeyFormat` value such as `JsonWebKey2020` or `Multikey`. The
 <em>options</em> `enableExperimentalPublicKeyTypes` value SHOULD be set to
 `false`. Defaults MAY be overridden by the caller of this algorithm.
 A <em>document</em> is the resulting output.
@@ -420,7 +420,8 @@ Set the <em>verification method</em> `id` value by concatenating
 <em>identifier</em>, a hash character (`#`), and the <em>multicodec value</em>.
             </li>
             <li>
-Set the <em>key encoding type</em> value to the <em>options</em> `type` value.
+Set the <em>key encoding type</em> value to the <em>options</em>
+`publicKeyFormat` value.
             </li>
             <li>
 If <em>key encoding type</em> is not known to the implementation, an
@@ -553,7 +554,8 @@ Set the <em>verification method</em> `id` value by concatenating
 <em>identifier</em>, a hash character (`#`), and the <em>multibase value</em>.
             </li>
             <li>
-Set the <em>key encoding type</em> value to the <em>options</em> `type` value.
+Set the <em>key encoding type</em> value to the <em>options</em>
+`publicKeyFormat` value.
             </li>
             <li>
 If <em>key encoding type</em> is not known to the implementation, an

--- a/index.html
+++ b/index.html
@@ -477,6 +477,22 @@ Return <em>multicodec value</em> and <em>raw public key bytes</em> as the
           </ol>
         </section>
 
+        <section class="normative">
+          <h4>Encode JWK Algorithm</h4>
+
+          <p>
+The following algorithm can be used to encode a multicodec value to a
+JSON Web Key. A <em>multicodec value</em>, <em>raw public key bytes</em>,
+and <em>options</em> are the required inputs. An <em>encoded JWK</em> is
+the output.
+          </p>
+
+          <p class="issue">
+Add the various was of transforming multicodec values and raw public key bytes
+to the JSON Web Key format.
+          </p>
+        </section>
+
       </section>
 
       <section class="normative">

--- a/index.html
+++ b/index.html
@@ -243,29 +243,29 @@ associated DID Document:
           {
             "@context": [
               "https://www.w3.org/ns/did/v1",
-              "https://w3id.org/security/suites/ed25519-2018/v1",
-              "https://w3id.org/security/suites/x25519-2019/v1"
+              "https://w3id.org/security/suites/ed25519-2020/v1",
+              "https://w3id.org/security/suites/x25519-2020/v1"
             ],
             "id": "did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2",
             "verificationMethod": [
               {
                 "id": "did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2",
-                "type": "Ed25519VerificationKey2018",
+                "type": "Ed25519VerificationKey2020",
                 "controller": "did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2",
-                "publicKeyBase58": "5ANg2DZ4jk7VGtHHsv3SGKjvi79WHvfNp9L6woYPqQqe"
+                "publicKeyMultibase": "z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2"
               },
               {
-                "id": "did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#z6LSni4ALZW58RuBPizpNeTK3HGfZfSuE3zcxeBubnrssYuh",
-                "type": "X25519KeyAgreementKey2019",
+                "id": "did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#zC2szpFhD2yBSJLd3qzwMih4BiWunXSpU5fUE7LDMAB8w",
+                "type": "X25519KeyAgreementKey2020",
                 "controller": "did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2",
-                "publicKeyBase58": "C2szpFhD2yBSJLd3qzwMih4BiWunXSpU5fUE7LDMAB8w"
+                "publicKeyMultibase": "zC2szpFhD2yBSJLd3qzwMih4BiWunXSpU5fUE7LDMAB8w"
               }
             ],
             "assertionMethod": ["did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2"],
             "authentication": ["did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2"],
             "capabilityInvocation": ["did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2"],
             "capabilityDelegation": ["did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2"],
-            "keyAgreement": ["did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#z6LSni4ALZW58RuBPizpNeTK3HGfZfSuE3zcxeBubnrssYuh"]
+            "keyAgreement": ["did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#zC2szpFhD2yBSJLd3qzwMih4BiWunXSpU5fUE7LDMAB8w"]
           }
         </pre>
 

--- a/index.html
+++ b/index.html
@@ -274,8 +274,10 @@ associated DID Document:
 
           <p>
 The following algorithm can be used for expanding a did:key identifier to a DID
-Document. An <em>identifier</em> and <em>options</em> are the required inputs. A
-<em>document</em> is the resulting output.
+Document. An <em>identifier</em> and <em>options</em> are the required inputs.
+Implementations are expected to set a reasonable default for the
+<em>options</em> `type` value such as `JsonWebKey2020` or `Multikey`.
+A <em>document</em> is the resulting output.
           </p>
 
           <ol class="algorithm">
@@ -416,8 +418,11 @@ Set the <em>verification method</em> `id` value by concatenating
 <em>identifier</em>, a hash character (`#`), and the <em>multicodec value</em>.
             </li>
             <li>
-Set the <em>key encoding type</em> value to the <em>options</em> `type` value
-if it is set, or `Multikey` if it is not set.
+Set the <em>key encoding type</em> value to the <em>options</em> `type` value.
+            </li>
+            <li>
+If <em>key encoding type</em> is not known to the implementation, an
+UNSUPPORTED_PUBLIC_KEY_TYPE error MUST be raised.
             </li>
             <li>
 If <em>options</em> `allowExperimentalPublicKeyTypes` is not set to `true` and
@@ -546,8 +551,11 @@ Set the <em>verification method</em> `id` value by concatenating
 <em>identifier</em>, a hash character (`#`), and the <em>multibase value</em>.
             </li>
             <li>
-Set the <em>key encoding type</em> value to the <em>options</em> `type` value
-if it is set, or `Multikey` if it is not set.
+Set the <em>key encoding type</em> value to the <em>options</em> `type` value.
+            </li>
+            <li>
+If <em>key encoding type</em> is not known to the implementation, an
+UNSUPPORTED_PUBLIC_KEY_TYPE error MUST be raised.
             </li>
             <li>
 If <em>options</em> `allowExperimentalPublicKeyTypes` is not set to `true` and

--- a/index.html
+++ b/index.html
@@ -270,7 +270,7 @@ associated DID Document:
         </pre>
 
         <section class="normative">
-          <h4>Expansion Algorithm</h4>
+          <h4>Document Creation Algorithm</h4>
 
           <p>
 The following algorithm can be used for expanding a did:key identifier to a DID
@@ -297,19 +297,14 @@ the value `did`. The <em>method</em> MUST be the value `key`. The
 of these requirements fail, an INVALID_DID error MUST be raised.
             </li>
             <li>
-Decode <em>multibase value</em> using the base58-btc multibase alphabet and set
-<em>multicodec value</em> to the multicodec header for the decoded value and
-the <em>raw public key bytes</em> to the bytes remaining after the multicodec
-header. Implementers are cautioned to ensure that <em>multicodec value</em>
-is set to the result after performing varint decoding.
-            </li>
-            <li>
 Initialize the <em>signature verification method</em> to the result of passing
-<em>options</em> to the <a href="#signature-method-expansion-algorithm"></a>.
+<em>identifier</em>, <em>multibase value</em>, and <em>options</em> to
+<a href="#signature-method-creation-algorithm"></a>.
             </li>
             <li>
 Initialize the <em>encryption verification method</em> to the result of passing
-<em>options</em> to the <a href="#encryption-method-expansion-algorithm"></a>.
+<em>identifier</em>, <em>multibase value</em>, and <em>options</em> to
+<a href="#encryption-method-creation-algorithm"></a>.
             </li>
             <li>
 Set the `id` property in <em>document</em> to <em>identifier</em>.
@@ -327,7 +322,7 @@ where the first item is the value of the `id` property in
             </li>
             <li>
 Initialize the `keyAgreement` property in <em>document</em> to an array
-where the first item is the value of he `id` property in
+where the first item is the value of the `id` property in
 <em>encryption verification method</em>.
             </li>
             <li>
@@ -341,12 +336,116 @@ output from the algorithm above.
         </section>
 
         <section class="normative">
-          <h4>Signature Method Expansion Algorithm</h4>
+          <h4>Signature Method Creation Algorithm</h4>
+
+          <p>
+The following algorithm can be used for decoding a multibase-encoded multicodec
+value into a verification method that is suitable for verifying digital
+signatures. An <em>identifier</em>, <em>multibase value</em>, and
+<em>options</em> are the required inputs. A <em>verification method</em> is
+the resulting output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize <em>verification method</em> to an empty object.
+            </li>
+            <li>
+Set <em>multicodec value</em> and <em>raw public key bytes</em> to the result
+of passing <em>multibase value</em> and <em>options</em> to
+<a href="#decode-public-key-algorithm"></a>.
+            </li>
+            <li>
+Ensure the proper key length of <em>raw public key bytes</em> based on the
+<em>multicodec value</em> table provided below:
+              <table class="simple">
+                <thead>
+                  <th>Multicodec hexadecimal value</th>
+                  <th>public key byte length</th>
+                  <th>Description</th>
+                </thead>
+
+                <tbody>
+                  <tr>
+                    <td>`0xe7`</td>
+                    <td>33 bytes</td>
+                    <td>secp256k1-pub - Secp256k1 public key (compressed)</td>
+                  </tr>
+                  <tr>
+                    <td>`0xec`</td>
+                    <td>32 bytes</td>
+                    <td>x25519-pub - Curve25519 public key</td>
+                  </tr>
+                  <tr>
+                    <td>`0xed`</td>
+                    <td>32 bytes</td>
+                    <td>ed25519-pub - Ed25519 public key</td>
+                  </tr>
+                  <tr>
+                    <td>`0x1200`</td>
+                    <td>33 bytes</td>
+                    <td>p256-pub - P-256 public key (compressed)</td>
+                  </tr>
+                  <tr>
+                    <td>`0x1201`</td>
+                    <td>?? bytes</td>
+                    <td>p384-pub - P-384 public key (compressed)</td>
+                  </tr>
+                  <tr>
+                    <td>`0x1202`</td>
+                    <td>?? bytes</td>
+                    <td>p521-pub - P-521 public key (compressed)</td>
+                  </tr>
+                  <tr>
+                    <td>`0x1205`</td>
+                    <td>?? bytes</td>
+                    <td>
+rsa-pub - RSA public key. DER-encoded ASN.1 type RSAPublicKey according to
+IETF RFC 8017 (PKCS #1)
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+If the byte length of <em>raw public key bytes</em> does not match the expected
+public key length for the associated <em>multicodec value</em>, an
+INVALID_PUBLIC_KEY_LENGTH error MUST be raised.
+            </li>
+            <li>
+Set the <em>verification method</em> `id` value by concatenating
+<em>identifier</em>, a hash character (`#`), and the <em>multicodec value</em>.
+            </li>
+            <li>
+Set the <em>key encoding type</em> value to the <em>options</em> `type` value
+if it is set, or `Multikey` if it is not set.
+            </li>
+            <li>
+If <em>options</em> `allowExperimentalPublicKeyTypes` is not set to `true` and
+<em>key encoding type</em> is not `Multikey`, `JsonWebKey2020`, or
+`Ed25519VerificationKey2020`, an INVALID_PUBLIC_KEY_TYPE error MUST be raised.
+            </li>
+            <li>
+Set the <em>verification method</em> `type` to the <em>key encoding type</em>.
+            </li>
+            <li>
+Set the <em>verification method</em> `controller` to <em>identifier</em>.
+            </li>
+            <li>
+If <em>key encoding type</em> is `Multikey` or `Ed25519VerificationKey2020`,
+set the <em>verification method</em> `publicKeyMultibase` value to
+<em>multibase value</em>.
+            <li>
+If <em>key encoding type</em> is `JsonWebKey2020`, set the
+<em>verification method</em> `publicKeyJwk` value to the result of
+passing <em>multicodec value</em> and <em>raw public key bytes</em> to
+<a href="#encode-jwk-algorithm"></a>.
+            </li>
+            <li>
+Return <em>verification method</em>.
+            </li>
+          </ol>
+
         </section>
 
-        <section class="normative">
-          <h4>Encryption Method Expansion Algorithm</h4>
-        </section>
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -239,34 +239,39 @@ below that expands the ed25519 <tt>did:key</tt>
 associated DID Document:
         </p>
 
-        <pre class="example" title="A DID Document derived from a did:key">
-          {
-            "@context": [
-              "https://www.w3.org/ns/did/v1",
-              "https://w3id.org/security/suites/ed25519-2020/v1",
-              "https://w3id.org/security/suites/x25519-2020/v1"
-            ],
-            "id": "did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2",
-            "verificationMethod": [
-              {
-                "id": "did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2",
-                "type": "Ed25519VerificationKey2020",
-                "controller": "did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2",
-                "publicKeyMultibase": "z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2"
-              },
-              {
-                "id": "did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#zC2szpFhD2yBSJLd3qzwMih4BiWunXSpU5fUE7LDMAB8w",
-                "type": "X25519KeyAgreementKey2020",
-                "controller": "did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2",
-                "publicKeyMultibase": "zC2szpFhD2yBSJLd3qzwMih4BiWunXSpU5fUE7LDMAB8w"
-              }
-            ],
-            "assertionMethod": ["did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2"],
-            "authentication": ["did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2"],
-            "capabilityInvocation": ["did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2"],
-            "capabilityDelegation": ["did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2"],
-            "keyAgreement": ["did:key:z6MkicdicToW5HbxPP7zZV1H7RHvXgRMhoujWAF2n5WQkdd2#zC2szpFhD2yBSJLd3qzwMih4BiWunXSpU5fUE7LDMAB8w"]
-          }
+        <pre class="example" title="An example of a did:key DID Document">
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/suites/ed25519-2020/v1",
+    "https://w3id.org/security/suites/x25519-2020/v1"
+  ],
+  "id": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+  "verificationMethod": [{
+    "id": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+    "type": "Ed25519VerificationKey2020",
+    "controller": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+    "publicKeyMultibase": "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+  }],
+  "authentication": [
+    "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+  ],
+  "assertionMethod": [
+    "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+  ],
+  "capabilityDelegation": [
+    "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+  ],
+  "capabilityInvocation": [
+    "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+  ],
+  "keyAgreement": [{
+    "id": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6LSj72tK8brWgZja8NLRwPigth2T9QRiG1uH9oKZuKjdh9p",
+    "type": "X25519KeyAgreementKey2020",
+    "controller": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+    "publicKeyMultibase": "z6LSj72tK8brWgZja8NLRwPigth2T9QRiG1uH9oKZuKjdh9p"
+  }]
+}
         </pre>
 
         <section class="normative">


### PR DESCRIPTION
Many of the [implementations](https://w3c.github.io/did-test-suite/#M23) we have today have guessed on the particular algorithm to create a did:key-based DID Document (and gotten it right for the most part). Now that we're working on a [continuous integration test suite](https://github.com/w3c-ccg/did-key-test-suite) for the did:key method, we need finalized normative statements to ensure multi-implementation interoperability.

This PR adds the normative statements for the DID Document creation algorithm. The algorithm takes options as an input, such as the desired public key format, to modify the final DID Document that is output.

Look at the "Diff" below -- highlighted yellow sections are new content. It's not fully complete yet -- wording could be improved, the JWK transformation section still needs to be written, but I hope to do that (or ideally, others that have implemented that) to do that in another PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-method-key/pull/51.html" title="Last updated on Jun 16, 2022, 2:04 AM UTC (49be877)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-method-key/51/0df342b...49be877.html" title="Last updated on Jun 16, 2022, 2:04 AM UTC (49be877)">Diff</a>