### PR TITLE
Camel case error names

### DIFF
--- a/index.html
+++ b/index.html
@@ -465,7 +465,7 @@ value.
             </li>
             <li>
 If <em>publicKeyFormat</em> is not known to the implementation, an
-UNSUPPORTED_PUBLIC_KEY_TYPE error MUST be raised.
+unsupportedPublicKeyType error MUST be raised.
             </li>
             <li>
 If <em>options.enableExperimentalPublicKeyTypes</em> is set to `false` and
@@ -603,7 +603,7 @@ value.
             </li>
             <li>
 If <em>publicKeyFormat</em> is not known to the implementation, an
-UNSUPPORTED_PUBLIC_KEY_TYPE error MUST be raised.
+unsupportedPublicKeyType error MUST be raised.
             </li>
             <li>
 If <em>options.enableExperimentalPublicKeyTypes</em> is set to `false` and

--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@ IETF RFC 8017 (PKCS #1)
               </table>
 If the byte length of <em>rawPublicKeyBytes</em> does not match the expected
 public key length for the associated <em>multicodecValue</em>, an
-INVALID_PUBLIC_KEY_LENGTH error MUST be raised.
+invalidPublicKeyLength error MUST be raised.
             </li>
             <li>
 Ensure the <em>rawPublicKeyBytes</em> are a proper encoding of the public key
@@ -584,7 +584,7 @@ Ensure the proper key length of <em>rawPublicKeyBytes</em> based on the
               </table>
 If the byte length of <em>rawPublicKeyBytes</em> does not match the expected
 public key length for the associated <em>multicodecValue</em>, an
-INVALID_PUBLIC_KEY_LENGTH error MUST be raised.
+invalidPublicKeyLength error MUST be raised.
             </li>
             <li>
 Create the <em>multibaseValue</em> by concatenating the letter 'z' and the

--- a/index.html
+++ b/index.html
@@ -456,7 +456,7 @@ particular feature.
             <li>
 Set the <em>verificationMethod.id</em> value by concatenating
 <em>identifier</em>, a hash character (`#`), and the <em>multicodecValue</em>.
-If <em>verificationMethod.id</em> is not a valid DID URL, an INVALID_DID_URL
+If <em>verificationMethod.id</em> is not a valid DID URL, an invalidDidUrl
 error MUST be raised.
             </li>
             <li>
@@ -594,7 +594,7 @@ the <em>rawPublicKeyBytes</em>.
             <li>
 Set the <em>verificationMethod.id</em> value by concatenating
 <em>identifier</em>, a hash character (`#`), and the <em>multibaseValue</em>.
-If <em>verificationMethod.id</em> is not a valid DID URL, an INVALID_DID_URL
+If <em>verificationMethod.id</em> is not a valid DID URL, an invalidDidUrl
 error MUST be raised.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -445,7 +445,7 @@ type as specified by the <em>multicodecValue</em>. This validation is often
 done by a cryptographic library when importing the public key by, for example,
 ensuring that an Elliptic Curve public key is a specific coordinate that exists
 on the elliptic curve. If an invalid public key value is detected, an
-INVALID_PUBLIC_KEY error MUST be raised.
+invalidPublicKey error MUST be raised.
 
 <div class="issue" title="Request for feedback on implementability">
 It is not clear if this particular check is implementable across all public

--- a/index.html
+++ b/index.html
@@ -309,7 +309,7 @@ Check the validity of the input <em>identifier</em>. The <em>scheme</em> MUST be
 the value `did`. The <em>method</em> MUST be the value `key`. The
 <em>version</em> MUST be convertible to a positive integer value. The
 <em>multibaseValue</em> MUST be a string and begin with the letter `z`. If any
-of these requirements fail, an invalidDid error MUST be raised.
+of these requirements fail, an `invalidDid` error MUST be raised.
             </li>
             <li>
 Initialize the <em>signatureVerificationMethod</em> to the result of passing
@@ -318,7 +318,7 @@ Initialize the <em>signatureVerificationMethod</em> to the result of passing
             </li>
             <li>
 Set <em>document.id</em> to <em>identifier</em>. If <em>document.id</em> is not
-a valid DID, an invalidDid error MUST be raised.
+a valid DID, an `invalidDid` error MUST be raised.
             </li>
             <li>
 Initialize the `verificationMethod` property in <em>document</em> to an array
@@ -437,7 +437,7 @@ IETF RFC 8017 (PKCS #1)
               </table>
 If the byte length of <em>rawPublicKeyBytes</em> does not match the expected
 public key length for the associated <em>multicodecValue</em>, an
-invalidPublicKeyLength error MUST be raised.
+`invalidPublicKeyLength` error MUST be raised.
             </li>
             <li>
 Ensure the <em>rawPublicKeyBytes</em> are a proper encoding of the public key
@@ -445,7 +445,7 @@ type as specified by the <em>multicodecValue</em>. This validation is often
 done by a cryptographic library when importing the public key by, for example,
 ensuring that an Elliptic Curve public key is a specific coordinate that exists
 on the elliptic curve. If an invalid public key value is detected, an
-invalidPublicKey error MUST be raised.
+`invalidPublicKey` error MUST be raised.
 
 <div class="issue" title="Request for feedback on implementability">
 It is not clear if this particular check is implementable across all public
@@ -456,7 +456,7 @@ particular feature.
             <li>
 Set the <em>verificationMethod.id</em> value by concatenating
 <em>identifier</em>, a hash character (`#`), and the <em>multicodecValue</em>.
-If <em>verificationMethod.id</em> is not a valid DID URL, an invalidDidUrl
+If <em>verificationMethod.id</em> is not a valid DID URL, an `invalidDidUrl`
 error MUST be raised.
             </li>
             <li>
@@ -465,19 +465,19 @@ value.
             </li>
             <li>
 If <em>publicKeyFormat</em> is not known to the implementation, an
-unsupportedPublicKeyType error MUST be raised.
+`unsupportedPublicKeyType` error MUST be raised.
             </li>
             <li>
 If <em>options.enableExperimentalPublicKeyTypes</em> is set to `false` and
 <em>publicKeyFormat</em> is not `Multikey`, `JsonWebKey2020`, or
-`Ed25519VerificationKey2020`, an invalidPublicKeyType error MUST be raised.
+`Ed25519VerificationKey2020`, an `invalidPublicKeyType` error MUST be raised.
             </li>
             <li>
 Set <em>verificationMethod.type</em> to the <em>publicKeyFormat</em> value.
             </li>
             <li>
 Set <em>verificationMethod.controller</em> to the <em>identifier</em> value.
-If <em>verificationMethod.controller</em> is not a valid DID, an invalidDid
+If <em>verificationMethod.controller</em> is not a valid DID, an `invalidDid`
 error MUST be raised.
             </li>
             <li>
@@ -584,7 +584,7 @@ Ensure the proper key length of <em>rawPublicKeyBytes</em> based on the
               </table>
 If the byte length of <em>rawPublicKeyBytes</em> does not match the expected
 public key length for the associated <em>multicodecValue</em>, an
-invalidPublicKeyLength error MUST be raised.
+`invalidPublicKeyLength` error MUST be raised.
             </li>
             <li>
 Create the <em>multibaseValue</em> by concatenating the letter 'z' and the
@@ -594,7 +594,7 @@ the <em>rawPublicKeyBytes</em>.
             <li>
 Set the <em>verificationMethod.id</em> value by concatenating
 <em>identifier</em>, a hash character (`#`), and the <em>multibaseValue</em>.
-If <em>verificationMethod.id</em> is not a valid DID URL, an invalidDidUrl
+If <em>verificationMethod.id</em> is not a valid DID URL, an `invalidDidUrl`
 error MUST be raised.
             </li>
             <li>
@@ -603,12 +603,12 @@ value.
             </li>
             <li>
 If <em>publicKeyFormat</em> is not known to the implementation, an
-unsupportedPublicKeyType error MUST be raised.
+`unsupportedPublicKeyType` error MUST be raised.
             </li>
             <li>
 If <em>options.enableExperimentalPublicKeyTypes</em> is set to `false` and
 <em>publicKeyFormat</em> is not `Multikey`, `JsonWebKey2020`, or
-`X25519KeyAgreementKey2020`, an invalidPublicKeyType error MUST be raised.
+`X25519KeyAgreementKey2020`, an `invalidPublicKeyType` error MUST be raised.
             </li>
             <li>
 Set <em>verificationMethod.type</em> to the <em>publicKeyFormat</em> value.
@@ -616,7 +616,7 @@ Set <em>verificationMethod.type</em> to the <em>publicKeyFormat</em> value.
             <li>
 Set <em>verificationMethod.controller</em> to <em>identifier</em>. If
 <em>verificationMethod.controller</em> is not a valid DID, an
-invalidDid error MUST be raised.
+`invalidDid` error MUST be raised.
             </li>
             <li>
 If <em>publicKeyFormat</em> is `Multikey` or `X25519KeyAgreementKey2020`,

--- a/index.html
+++ b/index.html
@@ -470,7 +470,7 @@ unsupportedPublicKeyType error MUST be raised.
             <li>
 If <em>options.enableExperimentalPublicKeyTypes</em> is set to `false` and
 <em>publicKeyFormat</em> is not `Multikey`, `JsonWebKey2020`, or
-`Ed25519VerificationKey2020`, an INVALID_PUBLIC_KEY_TYPE error MUST be raised.
+`Ed25519VerificationKey2020`, an invalidPublicKeyType error MUST be raised.
             </li>
             <li>
 Set <em>verificationMethod.type</em> to the <em>publicKeyFormat</em> value.
@@ -608,7 +608,7 @@ unsupportedPublicKeyType error MUST be raised.
             <li>
 If <em>options.enableExperimentalPublicKeyTypes</em> is set to `false` and
 <em>publicKeyFormat</em> is not `Multikey`, `JsonWebKey2020`, or
-`X25519KeyAgreementKey2020`, an INVALID_PUBLIC_KEY_TYPE error MUST be raised.
+`X25519KeyAgreementKey2020`, an invalidPublicKeyType error MUST be raised.
             </li>
             <li>
 Set <em>verificationMethod.type</em> to the <em>publicKeyFormat</em> value.

--- a/index.html
+++ b/index.html
@@ -309,7 +309,7 @@ Check the validity of the input <em>identifier</em>. The <em>scheme</em> MUST be
 the value `did`. The <em>method</em> MUST be the value `key`. The
 <em>version</em> MUST be convertible to a positive integer value. The
 <em>multibaseValue</em> MUST be a string and begin with the letter `z`. If any
-of these requirements fail, an INVALID_DID error MUST be raised.
+of these requirements fail, an invalidDid error MUST be raised.
             </li>
             <li>
 Initialize the <em>signatureVerificationMethod</em> to the result of passing
@@ -318,7 +318,7 @@ Initialize the <em>signatureVerificationMethod</em> to the result of passing
             </li>
             <li>
 Set <em>document.id</em> to <em>identifier</em>. If <em>document.id</em> is not
-a valid DID, an INVALID_DID error MUST be raised.
+a valid DID, an invalidDid error MUST be raised.
             </li>
             <li>
 Initialize the `verificationMethod` property in <em>document</em> to an array
@@ -477,7 +477,7 @@ Set <em>verificationMethod.type</em> to the <em>publicKeyFormat</em> value.
             </li>
             <li>
 Set <em>verificationMethod.controller</em> to the <em>identifier</em> value.
-If <em>verificationMethod.controller</em> is not a valid DID, an INVALID_DID
+If <em>verificationMethod.controller</em> is not a valid DID, an invalidDid
 error MUST be raised.
             </li>
             <li>
@@ -616,7 +616,7 @@ Set <em>verificationMethod.type</em> to the <em>publicKeyFormat</em> value.
             <li>
 Set <em>verificationMethod.controller</em> to <em>identifier</em>. If
 <em>verificationMethod.controller</em> is not a valid DID, an
-INVALID_DID error MUST be raised.
+invalidDid error MUST be raised.
             </li>
             <li>
 If <em>publicKeyFormat</em> is `Multikey` or `X25519KeyAgreementKey2020`,


### PR DESCRIPTION
Changes errors from `SHOUTY_SNAKE_CASE` to `camelCase`.
This is so the errors match the styles found in the [did resolver spec](https://w3c-ccg.github.io/did-resolution/#resolving), [did core spec](https://www.w3.org/TR/did-core/), and [did spec registries](https://www.w3.org/TR/did-spec-registries/)

Errors changed:

 - INVALID_PUBLIC_KEY_LENGTH
 - INVALID_PUBLIC_KEY
 - INVALID_DID_URL
 - UNSUPPORTED_PUBLIC_KEY_TYPE
 - INVALID_PUBLIC_KEY_TYPE


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aljones15/did-method-key/pull/59.html" title="Last updated on Jul 27, 2022, 7:02 PM UTC (8c0f1ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-method-key/59/c9b61b9...aljones15:8c0f1ac.html" title="Last updated on Jul 27, 2022, 7:02 PM UTC (8c0f1ac)">Diff</a>