### PR TITLE
Specify methodNotSupported error for method not key.

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,10 +306,11 @@ components: a <em>scheme</em>, a <em>method</em>, a <em>version</em>, and a
             </li>
             <li>
 Check the validity of the input <em>identifier</em>. The <em>scheme</em> MUST be
-the value `did`. The <em>method</em> MUST be the value `key`. The
-<em>version</em> MUST be convertible to a positive integer value. The
-<em>multibaseValue</em> MUST be a string and begin with the letter `z`. If any
-of these requirements fail, an `invalidDid` error MUST be raised.
+the value `did`. If this requirement fails, an `invalidDid` error MUST be raised.
+The <em>method</em> MUST be the value `key`. If this requirement fails, a
+`methodNotSupported` error MUST be raised. The <em>version</em> MUST be convertible
+to a positive integer value. The <em>multibaseValue</em> MUST be a string and begin
+with the letter `z`. If any of these requirements fail, an `invalidDid` error MUST be raised.
             </li>
             <li>
 Initialize the <em>signatureVerificationMethod</em> to the result of passing


### PR DESCRIPTION
Uses more specific error codes from did resolution to improve error quality.

p.s. we could use `invalidPublicKey` if  `The multibaseValue MUST be a string and begin with the letter z`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aljones15/did-method-key/pull/65.html" title="Last updated on Nov 20, 2023, 2:48 PM UTC (e3e324d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-method-key/65/f5abee8...aljones15:e3e324d.html" title="Last updated on Nov 20, 2023, 2:48 PM UTC (e3e324d)">Diff</a>